### PR TITLE
responding with 404 from DELETE if attempting to DELETE invalid resource

### DIFF
--- a/animals/AnimalHandler.py
+++ b/animals/AnimalHandler.py
@@ -121,3 +121,5 @@ class AnimalHandler(BasicHandler):
         DELETE FROM animal
         WHERE id = ?
         """, ( id, ))
+
+        return cursor.rowcount != 0

--- a/customers/CustomerHandler.py
+++ b/customers/CustomerHandler.py
@@ -77,3 +77,5 @@ class CustomerHandler(BasicHandler):
         DELETE FROM Customer
         WHERE id = ?
         """, ( id, ))
+
+        return cursor.rowcount != 0

--- a/employees/EmployeeHandler.py
+++ b/employees/EmployeeHandler.py
@@ -115,3 +115,5 @@ class EmployeeHandler(BasicHandler):
         DELETE FROM Employee
         WHERE id = ?
         """, ( id, ))
+
+        return cursor.rowcount != 0

--- a/helpers/BasicHandler.py
+++ b/helpers/BasicHandler.py
@@ -41,7 +41,8 @@ class BasicHandler:
         return json.dumps(result)
 
     def delete(self, id):
-        self.__exec_query(lambda cursor: self._delete(cursor, id))
+        success = self.__exec_query(lambda cursor: self._delete(cursor, id))
+        return success
 
     # derived classes need to implement the below functions if they want to 
     # implement the corresponding functionality

--- a/locations/LocationHandler.py
+++ b/locations/LocationHandler.py
@@ -71,3 +71,5 @@ class LocationHandler(BasicHandler):
         DELETE FROM Location
         WHERE id = ?
         """, ( id, ))
+
+        return cursor.rowcount != 0

--- a/request_handler.py
+++ b/request_handler.py
@@ -124,12 +124,15 @@ class HandleRequests(BaseHTTPRequestHandler):
         self.wfile.write("".encode())
 
     def do_DELETE(self):
-        self._set_headers(204) # 204 - No Content
-
         (resource, id) = self.parse_url(self.path)
 
         resource_handler = self.get_resource_handler(resource)
-        resource_handler.delete(id)
+        success = resource_handler.delete(id)
+
+        if success:
+            self._set_headers(204) # 204 - No Content
+        else:
+            self._set_headers(404)
 
         self.wfile.write("".encode())
 


### PR DESCRIPTION
Just like in PUT, if you make a DELETE request for an ID that is not in the DB for the requested resource, the response will be a 404 now.